### PR TITLE
fix: nonce finding issue

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@defi-wonderland/gnosis-safe-proposor",
-  "version": "1.0.1",
+  "version": "1.0.2",
   "description": "Gnosis Safe helper for delegates",
   "main": "lib/propose-tx.js",
   "types": "lib/propose-tx.d.ts",

--- a/src/utils/gnosis.ts
+++ b/src/utils/gnosis.ts
@@ -41,15 +41,13 @@ export async function getLatestNonce(safe: string, chainId: number): Promise<num
       {
         params: {
           ordering: 'nonce',
-          limit: 1,
           executed: false,
           queued: true,
           trusted: true,
         },
       },
     );
-    const results = resp.data.results;
-    return results.length ? results[0].nonce : undefined;
+    return resp.data.results.find(result => result.nonce)?.nonce;
   } catch (e) {
     console.log(e);
     throw `Failed to fetch multisig latest nonce: ${JSON.stringify(e.response.data)}`;


### PR DESCRIPTION
When querying the latest tx in order to get the latest nonce, it is possible to get a tx without nonce (a receive tx). For that reason, we do query a lot of txs and then filter the one with the highest nonce.